### PR TITLE
Fix node selector argument

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -5,11 +5,10 @@
 K8S_CURL_ARGS="--cacert /run/secrets/kubernetes.io/serviceaccount/ca.crt"
 KUBE_API_ENDPOINT="${KUBE_API_ENDPOINT:-"https://kubernetes.default.svc:443"}"
 SLEEP_TIME="${SLEEP_TIME:-"30"}"
-NODE_SELECTOR="${NODE_SELECTOR}"
 
-NODE_SELECTOR="?labelSelector="
+LABEL_SELECTOR=""
 if [[ ! -z "${NODE_SELECTOR}" ]]; then
-  NODE_SELECTOR="labelSelector=${NODE_SELECTOR}"
+  LABEL_SELECTOR="?labelSelector=${NODE_SELECTOR}"
 fi
 
 if [[ -z "${DIGITALOCEAN_TOKEN}" ]]; then
@@ -32,7 +31,7 @@ function get_node_list(){
   K8S_TOKEN="$(cat /run/secrets/kubernetes.io/serviceaccount/token)"
   curl -s ${K8S_CURL_ARGS} \
     --header "Authorization: Bearer ${K8S_TOKEN}" \
-    "${KUBE_API_ENDPOINT}/api/v1/nodes?${NODE_SELECTOR}" \
+    "${KUBE_API_ENDPOINT}/api/v1/nodes${LABEL_SELECTOR}" \
   | jq -cr
 }
 


### PR DESCRIPTION
Closes #1 

Hey @mwthink, I know you were planning to re-write this, but I'd really appreciate a quick fix if possible, as I need this to finalise my setup.

This should fix the problem - the input is `NODE_SELECTOR` still. If this is not set, then we simply append nothing to the end of the `api/v1/nodes` endpoint. Otherwise, we append `?labelSelector=${NODE_SELECTOR}` to the endpoint.

If there any chance you could take a look? Thanks!