### PR TITLE
Add floating_ip label to node

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.1.1"
+appVersion: "0.2.0"
 description: Keeps DigitalOcean floating IPs assigned to your cluster
 name: floating-ip-controller
-version: 0.1.0
+version: 0.2.0

--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -6,4 +6,4 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["list"]
+  verbs: ["list", "patch"]

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 image:
   repository: mwthink/digitalocean-floatingip-controller
-  tag: v0.1.1
+  tag: v0.2.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/kustomize/kustomization.yaml
+++ b/kustomize/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 images:
 - name: floating-ip-controller
   newName: mwthink/digitalocean-floating-ip-controller
-  newTag: v0.1.3
+  newTag: v0.2.0

--- a/kustomize/rbac.yaml
+++ b/kustomize/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["list"]
+  verbs: ["list", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
By adding a label with the floating ip address we can use node selectors
on other pods to assign them to the node.

I have been unable to test the label removal code as I have been unable
to add a node to my cluster which becomes the 0th item in the list
without removing the currently assigned node.