### PR TITLE
Fix ClusterRoleBinding subject name

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.1.1"
 description: Keeps DigitalOcean floating IPs assigned to your cluster
 name: floating-ip-controller
-version: 0.1.0
+version: 0.1.1

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "floatingip-controller.fullname" . }}
+  name: floating-ip-controller
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
The service account name is hard coded to 'floating-ip-controller'
but the cluster role binding was generating this dynamically.

This commit goes with the hardcoded approach to stay consistent with
the cluster role and cluster role binding.